### PR TITLE
Add missing functions

### DIFF
--- a/src/ZigguratTools.jl
+++ b/src/ZigguratTools.jl
@@ -194,4 +194,16 @@ function symmetricsampleziggurat(zs::ZigguratSampler)
     ifelse(rand(Bool), x, -x)
 end
 
+function symmetricsampleziggurat(zs::ZigguratSampler, N)
+    out = Vector{Float64}(undef, N)
+    symmetricsampleziggurat!(out, zs)
+end
+
+function symmetricsampleziggurat!(out, zs::ZigguratSampler)
+    for i in eachindex(out)
+        out[i] = symmetricsampleziggurat(zs)
+    end
+    out
+end
+
 end # module ZigguratTools

--- a/src/ZigguratTools.jl
+++ b/src/ZigguratTools.jl
@@ -5,7 +5,7 @@ using Plots
 
 export buildziggurat, buildziggurat!
 export searchziggurat
-export sampleziggurat, symmetricsampleziggurat
+export sampleziggurat, sampleziggurat!, symmetricsampleziggurat, symmetricsampleziggurat!
 export plotziggurat
 export ZigguratSampler, xvalues, yvalues, xyvalues, layerarea
 

--- a/test/sampling_tests.jl
+++ b/test/sampling_tests.jl
@@ -3,8 +3,10 @@ using ZigguratTools, Test
 include("../utils/Normal.jl")
 using .Normal
 
-N = 10
-zs = ZigguratSampler(f, finv, F, N, tailsample)
+Nzig = 10
+Nsamp = 5
+
+zs = ZigguratSampler(f, finv, F, Nzig, tailsample)
 
 x = sampleziggurat(zs)
 @test x isa Float64
@@ -12,7 +14,37 @@ x = sampleziggurat(zs)
 @test !isinf(x)
 @test x >= 0
 
+xs = sampleziggurat(zs, Nsamp)
+@test length(xs) == Nsamp
+@test xs isa Vector{Float64}
+@test all(!isnan, xs)
+@test all(!isinf, xs)
+@test all(>=(0), xs)
+
+out = Vector{Float64}(undef, Nsamp)
+xs = sampleziggurat!(out, zs)
+@test xs === out
+@test length(xs) == Nsamp
+@test xs isa Vector{Float64}
+@test all(!isnan, xs)
+@test all(!isinf, xs)
+@test all(>=(0), xs)
+
 x = symmetricsampleziggurat(zs)
 @test x isa Float64
 @test !isnan(x)
 @test !isinf(x)
+
+xs = symmetricsampleziggurat(zs, Nsamp)
+@test length(xs) == Nsamp
+@test xs isa Vector{Float64}
+@test all(!isnan, xs)
+@test all(!isinf, xs)
+
+out = Vector{Float64}(undef, Nsamp)
+xs = symmetricsampleziggurat!(out, zs)
+@test xs === out
+@test length(xs) == Nsamp
+@test xs isa Vector{Float64}
+@test all(!isnan, xs)
+@test all(!isinf, xs)


### PR DESCRIPTION
The mutating version of sampleziggurat wasn't being exported or tested. For symmetricsampleziggurat there was not mutating implementation or multiple output version, so I also added those and their tests.